### PR TITLE
Ft/commit tag - bug fixes

### DIFF
--- a/dist/lib/Git.js
+++ b/dist/lib/Git.js
@@ -100,8 +100,7 @@ class Git {
      */
     pushBranch(branch) {
         return __awaiter(this, void 0, void 0, function* () {
-            const ret = yield exec_1.exec('git', ['push', '-u', '--tags', this.remoteName, branch], this.execOptions);
-            console.info('return ', ret);
+            yield exec_1.exec('git', ['push', '-u', '--tags', this.remoteName, branch], this.execOptions);
             return this;
         });
     }

--- a/dist/lib/Git.js
+++ b/dist/lib/Git.js
@@ -89,7 +89,7 @@ class Git {
     tagLatestCommit(tag) {
         return __awaiter(this, void 0, void 0, function* () {
             const { name, message } = tag;
-            yield exec_1.exec('git', ['tag', '-a', name, '-m', (message || '')], this.execOptions);
+            yield exec_1.exec('git', ['tag', '-a', name, '-m', (message || name)], this.execOptions);
             return this;
         });
     }
@@ -100,7 +100,7 @@ class Git {
      */
     pushBranch(branch) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield exec_1.exec('git', ['push', this.remoteName, branch], this.execOptions);
+            yield exec_1.exec('git', ['push', '-u', '--tags', this.remoteName, branch], this.execOptions);
             return this;
         });
     }

--- a/dist/lib/Git.js
+++ b/dist/lib/Git.js
@@ -100,7 +100,8 @@ class Git {
      */
     pushBranch(branch) {
         return __awaiter(this, void 0, void 0, function* () {
-            yield exec_1.exec('git', ['push', '-u', '--tags', this.remoteName, branch], this.execOptions);
+            const ret = yield exec_1.exec('git', ['push', '-u', '--tags', this.remoteName, branch], this.execOptions);
+            console.info('return ', ret);
             return this;
         });
     }

--- a/dist/utils/gitUtils.js
+++ b/dist/utils/gitUtils.js
@@ -50,7 +50,7 @@ function configureGit(gitOptions, remoteName = 'github', gitInterface) {
             listeners: {
                 stdline: core.debug,
                 stderr: (data) => {
-                    core.error(data.toString());
+                    core.warning(data.toString());
                 },
                 debug: core.debug,
             },

--- a/src/lib/Git.ts
+++ b/src/lib/Git.ts
@@ -6,7 +6,7 @@ export default class Git {
   private readonly remoteName: string;
 
   constructor(params?: { execOptions?: ExecOptions, remoteName?: string }) {
-    this.execOptions = params?.execOptions ;
+    this.execOptions = params?.execOptions;
     this.remoteName = params?.remoteName ?? 'github';
   }
 
@@ -76,7 +76,7 @@ export default class Git {
    */
   async tagLatestCommit(tag: Tag): Promise<Git> {
     const { name, message } = tag;
-    await exec('git', ['tag', '-a', name, '-m', (message || '')], this.execOptions);
+    await exec('git', ['tag', '-a', name, '-m', (message || name)], this.execOptions);
     return this;
   }
 
@@ -86,7 +86,7 @@ export default class Git {
    * @return {Promise<Git>}
    */
   async pushBranch(branch: string): Promise<Git> {
-    await exec('git', ['push', '--tags', this.remoteName, branch], this.execOptions);
+    await exec('git', ['push', '-u', '--tags', this.remoteName, branch], this.execOptions);
     return this;
   }
 

--- a/src/lib/Git.ts
+++ b/src/lib/Git.ts
@@ -86,7 +86,8 @@ export default class Git {
    * @return {Promise<Git>}
    */
   async pushBranch(branch: string): Promise<Git> {
-    await exec('git', ['push', '-u', '--tags', this.remoteName, branch], this.execOptions);
+    const ret = await exec('git', ['push', '-u', '--tags', this.remoteName, branch], this.execOptions);
+    console.info('return ', ret);
     return this;
   }
 

--- a/src/lib/Git.ts
+++ b/src/lib/Git.ts
@@ -86,8 +86,7 @@ export default class Git {
    * @return {Promise<Git>}
    */
   async pushBranch(branch: string): Promise<Git> {
-    const ret = await exec('git', ['push', '-u', '--tags', this.remoteName, branch], this.execOptions);
-    console.info('return ', ret);
+    await exec('git', ['push', '-u', '--tags', this.remoteName, branch], this.execOptions);
     return this;
   }
 

--- a/src/utils/gitUtils.ts
+++ b/src/utils/gitUtils.ts
@@ -19,7 +19,7 @@ export async function configureGit(gitOptions: CommitOptions,
     listeners: {
       stdline: core.debug,
       stderr: (data: Buffer) => {
-        core.error(data.toString());
+        core.warning(data.toString());
       },
       debug: core.debug,
     },


### PR DESCRIPTION
Bug fixes for problems that were found during manual testing in the GitHub actions environment
- Tags were not pushing -> added the `-u` flag to promote upstream (tests succeeded after that)
- Tags were not being created properly due to missing message -> set default message to be the new version number
- Inconsistent error stream, changed it to warnings (push action is successful but posts to stderr even with return code 0)
