### PR TITLE
Fix an issue when passing object for versionFile

### DIFF
--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -142,7 +142,7 @@ export async function getBumperOptions(): Promise<BumperOptionsFile> {
     }
   } else if (!bumperOptions.hasOwnProperty('versionFile')
     || !bumperOptions.versionFile
-    || (bumperOptions.versionFile as string).trim() === "") {
+    || (bumperOptions.versionFile instanceof String && (bumperOptions.versionFile as string).trim() === "")) {
     err("Version file is not defined in option file or workflow input.");
   } else {
     bumperOptions.versionFile = normalizeFiles([bumperOptions.versionFile])[0];


### PR DESCRIPTION
When you specify an object (`{path: string, line:number}`) for versionFile property,  [the existing code](https://github.com/margani/version-bumper/blob/ddb1e4b5e0450320fb77119279bcbe17916efd0d/src/utils/options.ts#L145):

```ts
  } else if (!bumperOptions.hasOwnProperty('versionFile')
    || !bumperOptions.versionFile
    || (bumperOptions.versionFile as string).trim() === "") {
    err("Version file is not defined in option file or workflow input.");
  } else {
    bumperOptions.versionFile = normalizeFiles([bumperOptions.versionFile])[0];
  }
```


is trying to cast it as string and call trim function, which produces the following errors:

```
Error: bumperOptions.versionFile.trim is not a function
Error: Error: bumperOptions.versionFile.trim is not a function, Validate options file or create an issue if this persists
```

but with the change in this PR, it will check if it's an string, and if you pass the object:

```json
    "versionFile": {
        "path": "<path to the version file>",
        "line": <the line number that has the version>
    },
```

it executes [the following line](https://github.com/margani/version-bumper/blob/ddb1e4b5e0450320fb77119279bcbe17916efd0d/src/utils/options.ts#L148):

```ts
    bumperOptions.versionFile = normalizeFiles([bumperOptions.versionFile])[0];
```